### PR TITLE
Script tweaks 310120

### DIFF
--- a/backupdb/backup.sh
+++ b/backupdb/backup.sh
@@ -16,11 +16,19 @@ database_name="${database_name##*( )}"
 database_name="${database_name%%*( )}"
 
 # Derive backup name by combining the dataabse name, timestamp and file extension
-backup_name=${database_name}_${timestamp}${file_extension}
+kolibri_backup_name=${database_name}_kolibri_${timestamp}${file_extension}
+
+baseline_backup_name=${database_name}_baseline_${timestamp}${file_extension}
 
 # Create database backup using credentials from environment variables 
-echo "Creating database backup"
-PGPASSWORD=$KOLIBRI_DATABASE_PASSWORD pg_dump $KOLIBRI_DATABASE_NAME -U $KOLIBRI_DATABASE_USER -h $KOLIBRI_DATABASE_HOST -p $KOLIBRI_DATABASE_PORT -Fc > ~/backups/"$backup_name"
+echo "Creating Kolibri database backup"
+PGPASSWORD=$KOLIBRI_DATABASE_PASSWORD pg_dump $KOLIBRI_DATABASE_NAME -U $KOLIBRI_DATABASE_USER -h $KOLIBRI_DATABASE_HOST -p $KOLIBRI_DATABASE_PORT -Fc > ~/backups/"$kolibri_backup_name"
+
+echo "Creating Baseline database backup"
+PGPASSWORD=$BASELINE_DATABASE_PASSWORD pg_dump $BASELINE_DATABASE_NAME -U $BASELINE_DATABASE_USER -h $BASELINE_DATABASE_HOST -p $BASELINE_DATABASE_PORT -Fc > ~/backups/"$baseline_backup_name"
+
+#remove spaces from names of backups
+rename "s/ //g" ~/backups/*.backup
 
 # Call script to remove backups older than 40 days
 ~/.scripts/backupdb/remove_old_backups.sh

--- a/config/increase_session_timeout.sh
+++ b/config/increase_session_timeout.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 #Increase idle session timeout to 15 mins
-sudo sed -i 's/KOLIBRI_SESSION_TIMEOUT=720/KOLIBRI_SESSION_TIMEOUT=900/g' .bashrc
+sudo sed -i 's/KOLIBRI_SESSION_TIMEOUT=720/KOLIBRI_SESSION_TIMEOUT=900/g' ~/.bashrc

--- a/config/increase_session_timeout.sh
+++ b/config/increase_session_timeout.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Increase idle session timeout to 15 mins
+sudo sed -i 's/KOLIBRI_SESSION_TIMEOUT=720/KOLIBRI_SESSION_TIMEOUT=900/g' .bashrc

--- a/upgrade_silent.sh
+++ b/upgrade_silent.sh
@@ -66,5 +66,7 @@ else
   echo "PostgreSQL is already installed. Skipping.."
 fi
 
+~/.scripts/config/increase_session_timeout.sh
+
 #Run backup script
 ~/.scripts/backupdb/backup.sh


### PR DESCRIPTION
Tweaks to do the following:

1. Increase idle session timeout to 15 mins
2. Get a backup of the baseline testing database in addition to Kolibri database when the backup script is invoked