### PR TITLE
Kolibri helper scripts upgrade

### DIFF
--- a/upgrade_silent.sh
+++ b/upgrade_silent.sh
@@ -74,7 +74,7 @@ if [ -d "$kolibri_helper_scripts_dir" ]; then
 	cd $kolibri_helper_scripts_dir && git reset --hard origin/master && git pull origin master && cd ~
 else
 	echo "Helper scripts directory does not exist. Cloning now..."
-	git clone https://github.com/techZM/kolibri_helper_scripts.git ~/.kolibri_helper_scripts
+	git clone https://github.com/techZM/kolibri_helper_scripts.git $kolibri_helper_scripts_dir
 fi
 
 #Run backup script

--- a/upgrade_silent.sh
+++ b/upgrade_silent.sh
@@ -68,5 +68,7 @@ fi
 
 ~/.scripts/config/increase_session_timeout.sh
 
+cd ~/.kolibri_helper_scripts && git reset --hard origin/master && git pull origin master && cd ~
+
 #Run backup script
 ~/.scripts/backupdb/backup.sh

--- a/upgrade_silent.sh
+++ b/upgrade_silent.sh
@@ -8,6 +8,8 @@ chmod +x reporting/monthend.sh
 chmod +x reporting/send_report.sh
 chmod +x backupdb/remove_old_backups.sh
 
+kolibri_helper_scripts_dir=~/.kolibri_helper_scripts
+
 #make backups and reports directories if they don't exist
 DIRECTORIES=( ~/.reports ~/backups )
 for DIRECTORY in ${DIRECTORIES[@]}; do
@@ -68,7 +70,12 @@ fi
 
 ~/.scripts/config/increase_session_timeout.sh
 
-cd ~/.kolibri_helper_scripts && git reset --hard origin/master && git pull origin master && cd ~
+if [ -d "$kolibri_helper_scripts_dir" ]; then
+	cd $kolibri_helper_scripts_dir && git reset --hard origin/master && git pull origin master && cd ~
+else
+	echo "Helper scripts directory does not exist. Cloning now..."
+	git clone https://github.com/techZM/kolibri_helper_scripts.git ~/.kolibri_helper_scripts
+fi
 
 #Run backup script
 ~/.scripts/backupdb/backup.sh


### PR DESCRIPTION
This PR adds a line to upgrade_silent to update kolibri_helper_scripts to it's latest master branch. The assign_learners script and other commonly used tools for Kolibri support and daily operations reside in kolibri_helper_scripts