### PR TITLE
Create backups zip

### DIFF
--- a/backupdb/backup.sh
+++ b/backupdb/backup.sh
@@ -24,7 +24,7 @@ echo "Creating Baseline database backup"
 PGPASSWORD=$BASELINE_DATABASE_PASSWORD pg_dump $BASELINE_DATABASE_NAME -U $BASELINE_DATABASE_USER -h $BASELINE_DATABASE_HOST -p $BASELINE_DATABASE_PORT -Fc > ~/backups/"$baseline_backup_name"
 
 echo "Creating zip file with backups"
-zip -jm ~/backups/$zip_file_name ~/backups/"$kolibri_backup_name" ~/backups/"$baseline_backup_name"
+zip -jm ~/backups/"$zip_file_name" ~/backups/"$kolibri_backup_name" ~/backups/"$baseline_backup_name"
 
 #remove spaces from names of backups
 rename "s/ //g" ~/backups/*.backup

--- a/backupdb/backup.sh
+++ b/backupdb/backup.sh
@@ -12,8 +12,10 @@ database_name="$(PGPASSWORD=$KOLIBRI_DATABASE_PASSWORD psql -d $KOLIBRI_DATABASE
 # Derive backup name by combining the dataabse name, timestamp and file extension
 kolibri_backup_name=${database_name}_kolibri_${timestamp}${file_extension}
 
+# name of baseline backup
 baseline_backup_name=${database_name}_baseline_${timestamp}${file_extension}
 
+# name of zip file
 zip_file_name=${database_name}_backups_${timestamp}
 
 # Create database backup using credentials from environment variables 
@@ -24,6 +26,7 @@ echo "Creating Baseline database backup"
 PGPASSWORD=$BASELINE_DATABASE_PASSWORD pg_dump $BASELINE_DATABASE_NAME -U $BASELINE_DATABASE_USER -h $BASELINE_DATABASE_HOST -p $BASELINE_DATABASE_PORT -Fc > ~/backups/"$baseline_backup_name"
 
 echo "Creating zip file with backups"
+# create zip file containing both backups taken above and remove the original files
 zip -jm ~/backups/"$zip_file_name" ~/backups/"$kolibri_backup_name" ~/backups/"$baseline_backup_name"
 
 #remove spaces from names of backups

--- a/backupdb/backup.sh
+++ b/backupdb/backup.sh
@@ -6,19 +6,15 @@ file_extension=".backup"
 # Get today's date and use it as timestamp for database backup file
 timestamp=$(date +"%Y%m%d")
 
-# get database name using direct query on terminal
-database_name=$(PGPASSWORD=$KOLIBRI_DATABASE_PASSWORD psql -d $KOLIBRI_DATABASE_NAME -U $KOLIBRI_DATABASE_USER -h $KOLIBRI_DATABASE_HOST -p $KOLIBRI_DATABASE_PORT -t -c "select name from kolibriauth_collection where id = (select default_facility_id from device_devicesettings);")
-
-#remove leading whitespace
-database_name="${database_name##*( )}"
-
-#remove trailing whitespace
-database_name="${database_name%%*( )}"
+# get database name using direct query on terminal. remove leading and trailing whitespace
+database_name="$(PGPASSWORD=$KOLIBRI_DATABASE_PASSWORD psql -d $KOLIBRI_DATABASE_NAME -U $KOLIBRI_DATABASE_USER -h $KOLIBRI_DATABASE_HOST -p $KOLIBRI_DATABASE_PORT -t -c 'select name from kolibriauth_collection where id = (select default_facility_id from device_devicesettings);' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
 
 # Derive backup name by combining the dataabse name, timestamp and file extension
 kolibri_backup_name=${database_name}_kolibri_${timestamp}${file_extension}
 
 baseline_backup_name=${database_name}_baseline_${timestamp}${file_extension}
+
+zip_file_name=${database_name}_backups_${timestamp}
 
 # Create database backup using credentials from environment variables 
 echo "Creating Kolibri database backup"
@@ -26,6 +22,9 @@ PGPASSWORD=$KOLIBRI_DATABASE_PASSWORD pg_dump $KOLIBRI_DATABASE_NAME -U $KOLIBRI
 
 echo "Creating Baseline database backup"
 PGPASSWORD=$BASELINE_DATABASE_PASSWORD pg_dump $BASELINE_DATABASE_NAME -U $BASELINE_DATABASE_USER -h $BASELINE_DATABASE_HOST -p $BASELINE_DATABASE_PORT -Fc > ~/backups/"$baseline_backup_name"
+
+echo "Creating zip file with backups"
+zip -jm ~/backups/$zip_file_name ~/backups/"$kolibri_backup_name" ~/backups/"$baseline_backup_name"
 
 #remove spaces from names of backups
 rename "s/ //g" ~/backups/*.backup


### PR DESCRIPTION
This PR creates a zip file in the backups directory containing backups for both baseline and Kolibri on the day the backup was taken. It is an improvement on the previous backup script which was creating separate files for baseline and Kolibri. 
If the backup command is invoked many times on the same day, the zip file is updated. The naming convention for the zip files is <database_name>_backups_<current date>.zip